### PR TITLE
fix: update actions to v4 and correct artifact paths in on-release workflow

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -44,10 +44,10 @@ jobs:
         run: |
           uv build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
-          path: dist/
+          path: ./dist/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     permissions:
@@ -58,18 +58,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
-          path: dist/
+          path: ./dist/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload wheel and tar.gz to GitHub Releases
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            dist/*.whl
-            dist/*.tar.gz
+            ./dist/*.whl
+            ./dist/*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
@@ -95,13 +95,13 @@ jobs:
           python -m pip install uv
           uv sync --dev
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
-          path: dist/
+          path: ./dist/
       - name: Upload to PyPI
         run: |
-          uv run twine upload dist/*${{ github.event.release.tag_name }}*
+          uv run twine upload ./dist/*${{ github.event.release.tag_name }}*
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Fix a github action because https://github.com/hmasdev/pybizday_utils/actions/runs/14291903018 failed