### PR TITLE
Pin uv package version to 0.6.12 in workflow files

### DIFF
--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          python -m pip install uv
+          python -m pip install uv==0.6.12
           uv sync --dev
       - name: Code Style Check
         run: |

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          python -m pip install uv
+          python -m pip install uv==0.6.12
           uv sync --dev
       - name: Pytest
         run: |

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install requirements
         run: |
           python -m pip install --upgrade pip
-          python -m pip install uv
+          python -m pip install uv==0.6.12
           uv sync --dev
       - name: Static Type Check
         run: |


### PR DESCRIPTION
Update the installation command for the uv package in workflow files to ensure consistent behavior across environments.