### PR TITLE
Refactor business day calculation to avoid recursion errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,12 @@ version_file = "src/pybizday_utils/_version.py"
 minversion = "6.0"
 testpaths = ["tests"]
 addopts = "--cov=src --cov-report=term-missing --cov-report=xml"
-markers = ["positive", "negative", "use_global_default_holiday_discriminator"]
+markers = [
+    "positive",
+    "negative",
+    "heavy",
+    "use_global_default_holiday_discriminator",
+]
 
 [tool.mypy]
 strict = true

--- a/src/pybizday_utils/basic.py
+++ b/src/pybizday_utils/basic.py
@@ -174,7 +174,7 @@ def get_n_prev_bizday(
         return date
     elif n > 0:
         try:
-            # NOTE: recursive implemantation may cause RecursionError when n is large.  # noqa: E501
+            # NOTE: recursive implementation may cause RecursionError when n is large.  # noqa: E501
             for _ in range(n):
                 date = get_prev_bizday(date, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
         except ValueError as e:

--- a/src/pybizday_utils/basic.py
+++ b/src/pybizday_utils/basic.py
@@ -126,7 +126,7 @@ def get_n_next_bizday(
         return date
     elif n > 0:
         try:
-            # NOTE: recursive implemantation may cause RecursionError when n is large.  # noqa: E501
+            # NOTE: recursive implementation may cause RecursionError when n is large.  # noqa: E501
             for _ in range(n):
                 date = get_next_bizday(date, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
         except ValueError as e:

--- a/src/pybizday_utils/basic.py
+++ b/src/pybizday_utils/basic.py
@@ -112,7 +112,7 @@ def get_n_next_bizday(
 
     Raises:
         ValueError: If n=0 and the date is a holiday.
-        ValueError: If no next business day is found.
+        ValueError: If no n-th next business day is found.
 
     Returns:
         datetime.date: n-th next business day after the given date.
@@ -126,10 +126,12 @@ def get_n_next_bizday(
         return date
     elif n > 0:
         try:
-            next_bizday = get_next_bizday(date, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
+            # NOTE: recursive implemantation may cause RecursionError when n is large.  # noqa: E501
+            for _ in range(n):
+                date = get_next_bizday(date, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
         except ValueError as e:
-            raise ValueError(f'No next business day found: n = {n}') from e
-        return get_n_next_bizday(next_bizday, n - 1, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
+            raise ValueError(f'No {n}-th next business day found') from e
+        return date
     else:
         return get_n_prev_bizday(date, -n, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
 
@@ -172,10 +174,12 @@ def get_n_prev_bizday(
         return date
     elif n > 0:
         try:
-            prev_bizday = get_prev_bizday(date, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
+            # NOTE: recursive implemantation may cause RecursionError when n is large.  # noqa: E501
+            for _ in range(n):
+                date = get_prev_bizday(date, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
         except ValueError as e:
-            raise ValueError(f'No previous business day found: n = {n}') from e
-        return get_n_prev_bizday(prev_bizday, n - 1, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
+            raise ValueError(f'No {n}-th previous business day found') from e
+        return date
     else:
         return get_n_next_bizday(date, -n, is_holiday, datetime_handler=datetime_handler)  # noqa: E501
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -193,6 +193,16 @@ def test_get_n_next_bizday(
     assert get_n_next_bizday(date, n, is_holiday) == expected
 
 
+@pytest.mark.positive
+@pytest.mark.heavy
+def test_get_n_next_bizday_with_large_n() -> None:
+    date = datetime.date(2025, 4, 25)
+    n = 10000
+    actual = get_n_next_bizday(date, n, is_holiday=lambda _: False)
+    expected = date + datetime.timedelta(days=n)
+    assert actual == expected
+
+
 @pytest.mark.negative
 def test_get_n_next_bizday_with_n_0_and_date_holiday() -> None:
     date = datetime.date(2025, 4, 25)
@@ -304,6 +314,16 @@ def test_get_n_prev_bizday(
     expected: datetime.date,
 ) -> None:
     assert get_n_prev_bizday(date, n, is_holiday) == expected
+
+
+@pytest.mark.positive
+@pytest.mark.heavy
+def test_get_n_prev_bizday_with_large_n() -> None:
+    date = datetime.date(2025, 4, 25)
+    n = 10000
+    actual = get_n_prev_bizday(date, n, is_holiday=lambda _: False)
+    expected = date - datetime.timedelta(days=n)
+    assert actual == expected
 
 
 @pytest.mark.negative
@@ -816,9 +836,9 @@ def test_get_prev_bizday_should_raise_ValueError_if_no_prev_bizday_found() -> No
 @pytest.mark.parametrize(
     "d, n, expected_msg",
     [
-        (datetime.date.max - datetime.timedelta(days=10), 1, "No next business day found: n = 1"),  # noqa: E501
-        (datetime.date.max - datetime.timedelta(days=10), 2, "No next business day found: n = 2"),  # noqa: E501
-        (datetime.date.min + datetime.timedelta(days=10), -1, "No previous business day found: n = 1"),  # noqa: E501
+        (datetime.date.max - datetime.timedelta(days=10), 1, "No 1-th next business day found"),  # noqa: E501
+        (datetime.date.max - datetime.timedelta(days=10), 2, "No 2-th next business day found"),  # noqa: E501
+        (datetime.date.min + datetime.timedelta(days=10), -1, "No 1-th previous business day found"),  # noqa: E501
     ]
 )
 def test_get_n_next_bizday_should_raise_ValueError_if_no_next_bizday_found(
@@ -834,9 +854,9 @@ def test_get_n_next_bizday_should_raise_ValueError_if_no_next_bizday_found(
 @pytest.mark.parametrize(
     "d, n, expected_msg",
     [
-        (datetime.date.min + datetime.timedelta(days=10), 1, "No previous business day found: n = 1"),  # noqa: E501
-        (datetime.date.min + datetime.timedelta(days=10), 2, "No previous business day found: n = 2"),  # noqa: E501
-        (datetime.date.max - datetime.timedelta(days=10), -1, "No next business day found: n = 1"),  # noqa: E501
+        (datetime.date.min + datetime.timedelta(days=10), 1, "No 1-th previous business day found"),  # noqa: E501
+        (datetime.date.min + datetime.timedelta(days=10), 2, "No 2-th previous business day found"),  # noqa: E501
+        (datetime.date.max - datetime.timedelta(days=10), -1, "No 1-th next business day found"),  # noqa: E501
     ]
 )
 def test_get_n_prev_bizday_should_raise_ValueError_if_no_prev_bizday_found(


### PR DESCRIPTION
Replace the recursive approach for calculating the next and previous business days with a for loop to prevent potential RecursionErrors. Update tests to validate functionality with large values of n. Adjust error messages for clarity.