### PR TITLE
Add job to create GitHub issue on test failures

### DIFF
--- a/.github/workflows/on-scheduled.yaml
+++ b/.github/workflows/on-scheduled.yaml
@@ -18,3 +18,21 @@ jobs:
     uses: ./.github/workflows/code-style-check-workflow-call.yaml
     permissions:
       contents: read
+  create-issue-on-failure:
+    runs-on: ubuntu-latest
+    needs: [test, static-type-check, code-style-check]
+    if: |
+      needs.test.result == 'failure' ||
+      needs.static-type-check.result == 'failure' ||
+      needs.code-style-check.result == 'failure'
+    steps:
+      - name: Create Github Issue
+        run: |
+          gh issue create \
+            --title "Scheduled Tests Failed" \
+            --body "At least one job failed in the workflow run. See ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID} for more details." \
+            --label "bot,ci"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      issues: write


### PR DESCRIPTION
Introduce a new job that automatically creates a GitHub issue when scheduled tests fail, providing a link to the workflow run for more details.