### PR TITLE
Update PyPI upload command to use environment variable for release tag name

### DIFF
--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -101,7 +101,7 @@ jobs:
           path: ./dist/
       - name: Upload to PyPI
         run: |
-          uv run twine upload ./dist/*${GITHUB_EVENT_RELEASE_TAG_NAME}*
+          uv run twine upload "./dist/*${GITHUB_EVENT_RELEASE_TAG_NAME}*"
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -101,12 +101,13 @@ jobs:
           path: ./dist/
       - name: Upload to PyPI
         run: |
-          uv run twine upload ./dist/*${{ github.event.release.tag_name }}*
+          uv run twine upload ./dist/*${GITHUB_EVENT_RELEASE_TAG_NAME}*
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
           TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
           TWINE_SKIP_EXISTING: true
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Refactor the PyPI upload command to utilize an environment variable for the release tag name, enhancing flexibility and maintainability.