### PR TITLE
Update GitHub Actions for improved deployment process

### DIFF
--- a/.github/workflows/code-style-check-workflow-call.yaml
+++ b/.github/workflows/code-style-check-workflow-call.yaml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements

--- a/.github/workflows/on-release.yaml
+++ b/.github/workflows/on-release.yaml
@@ -53,7 +53,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-  deploy-to-github:
+  publish-to-github:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -64,50 +64,26 @@ jobs:
           path: ./dist/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload wheel and tar.gz to GitHub Releases
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            ./dist/*.whl
-            ./dist/*.tar.gz
+      - name: Upload distribution files to GitHub
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_RELEASE_ID: ${{ github.event.release.id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" dist/* --repo "$GITHUB_REPOSITORY" --clobber
     permissions:
       contents: write
-      packages: read
-  deploy-to-PyPI:
-    needs: [deploy-to-github]
+  publish-to-PyPI:
+    needs: [build]
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pybizday-utils
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install uv
-          uv sync --dev
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: ./dist/
-      - name: Upload to PyPI
-        run: |
-          uv run twine upload "./dist/*${GITHUB_EVENT_RELEASE_TAG_NAME}*"
-        env:
-          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          TWINE_REPOSITORY_URL: https://upload.pypi.org/legacy/
-          TWINE_SKIP_EXISTING: true
-          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
     permissions:
-      contents: read
-      packages: read
+      id-token: write

--- a/.github/workflows/pytest-workflow-call.yaml
+++ b/.github/workflows/pytest-workflow-call.yaml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements

--- a/.github/workflows/static-type-check-workflow-call.yaml
+++ b/.github/workflows/static-type-check-workflow-call.yaml
@@ -22,11 +22,11 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.git-ref }}
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install requirements


### PR DESCRIPTION
Upgrade to the latest versions of checkout and setup-python actions, and rename the deploy job to streamline the upload process to GitHub and PyPI.